### PR TITLE
making sure rox options builder have dynamic property rule, and that options uses it

### DIFF
--- a/server/rox_options.go
+++ b/server/rox_options.go
@@ -55,7 +55,7 @@ func NewRoxOptions(builder RoxOptionsBuilder) model.RoxOptions {
 		logging.SetLogger(NewServerLogger())
 	}
 
-	var dynamicPropertyRuleHandler model.DynamicPropertyRuleHandler = builder.DynamicPropertyRuleHandler
+	var dynamicPropertyRuleHandler = builder.DynamicPropertyRuleHandler
 	if dynamicPropertyRuleHandler == nil {
 		dynamicPropertyRuleHandler = func(args model.DynamicPropertyRuleHandlerArgs) interface{} {
 			if args.Context != nil {

--- a/server/rox_options.go
+++ b/server/rox_options.go
@@ -15,6 +15,7 @@ type RoxOptionsBuilder struct {
 	ConfigurationFetchedHandler model.ConfigurationFetchedHandler
 	RoxyURL                     string
 	SelfManagedOptions          model.SelfManagedOptions
+	DynamicPropertyRuleHandler  model.DynamicPropertyRuleHandler
 }
 
 type roxOptions struct {
@@ -54,7 +55,7 @@ func NewRoxOptions(builder RoxOptionsBuilder) model.RoxOptions {
 		logging.SetLogger(NewServerLogger())
 	}
 
-	var dynamicPropertyRuleHandler model.DynamicPropertyRuleHandler
+	var dynamicPropertyRuleHandler model.DynamicPropertyRuleHandler = builder.DynamicPropertyRuleHandler
 	if dynamicPropertyRuleHandler == nil {
 		dynamicPropertyRuleHandler = func(args model.DynamicPropertyRuleHandlerArgs) interface{} {
 			if args.Context != nil {


### PR DESCRIPTION
while fixing Ruby's doc i noticed GOlang does not have an example for DynamicPropertyRule
![image](https://user-images.githubusercontent.com/35894775/146857529-437c4fdf-f2d4-4089-9f89-7874da4b79d4.png)

writing an example failed to work, looks like DynamicPropertyRule was removed from the RoxOptionsBuilder, and only the default one is used in RoxOptions
think it was by mistake