### PR TITLE
add tags to flag structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 *.out
 
 *.idea
+*.iml

--- a/v5/core/client/dynamic_api.go
+++ b/v5/core/client/dynamic_api.go
@@ -22,7 +22,7 @@ func (api *dynamicAPI) IsEnabled(name string, defaultValue bool, ctx context.Con
 	flag := api.flagRepository.GetFlag(name)
 	if flag == nil {
 		flag = api.entitiesProvider.CreateFlag(defaultValue)
-		api.flagRepository.AddFlag(flag, name)
+		api.flagRepository.AddFlag(flag, name, name)
 	}
 
 	if flag, ok := flag.(model.Flag); !ok {
@@ -41,7 +41,7 @@ func (api *dynamicAPI) Value(name string, defaultValue string, options []string,
 	variant := api.flagRepository.GetFlag(name)
 	if variant == nil {
 		variant = api.entitiesProvider.CreateRoxString(defaultValue, options)
-		api.flagRepository.AddFlag(variant, name)
+		api.flagRepository.AddFlag(variant, name, name)
 	}
 
 	switch variant.FlagType() {
@@ -62,7 +62,7 @@ func (api *dynamicAPI) GetInt(name string, defaultValue int, options []int, ctx 
 	variant := api.flagRepository.GetFlag(name)
 	if variant == nil {
 		variant = api.entitiesProvider.CreateRoxInt(defaultValue, options)
-		api.flagRepository.AddFlag(variant, name)
+		api.flagRepository.AddFlag(variant, name, name)
 	}
 
 	switch variant.FlagType() {
@@ -83,7 +83,7 @@ func (api *dynamicAPI) GetDouble(name string, defaultValue float64, options []fl
 	variant := api.flagRepository.GetFlag(name)
 	if variant == nil {
 		variant = api.entitiesProvider.CreateRoxDouble(defaultValue, options)
-		api.flagRepository.AddFlag(variant, name)
+		api.flagRepository.AddFlag(variant, name, name)
 	}
 
 	switch variant.FlagType() {

--- a/v5/core/entities/flag_setter_test.go
+++ b/v5/core/entities/flag_setter_test.go
@@ -21,7 +21,7 @@ func TestFlagSetterWillSetFlagData(t *testing.T) {
 	internalFlags := &mocks.InternalFlags{}
 	impInvoker := impression.NewImpressionInvoker(internalFlags, nil, nil, false)
 
-	flagRepo.AddFlag(NewFlag(false), "f1")
+	flagRepo.AddFlag(NewFlag(false), "f1", "f1")
 	expRepo.SetExperiments([]*model.ExperimentModel{
 		model.NewExperimentModel("33", "1", "1", false, []string{"f1"}, nil),
 	})
@@ -45,8 +45,8 @@ func TestFlagSetterWillNotSetForOtherFlag(t *testing.T) {
 	internalFlags := &mocks.InternalFlags{}
 	impInvoker := impression.NewImpressionInvoker(internalFlags, nil, nil, false)
 
-	flagRepo.AddFlag(NewFlag(false), "f1")
-	flagRepo.AddFlag(NewFlag(false), "f2")
+	flagRepo.AddFlag(NewFlag(false), "f1", "f1")
+	flagRepo.AddFlag(NewFlag(false), "f2", "f2")
 	expRepo.SetExperiments([]*model.ExperimentModel{
 		model.NewExperimentModel("1", "1", "1", false, []string{"f1"}, nil),
 	})
@@ -71,7 +71,7 @@ func TestFlagSetterWillSetExperimentForFlagAndWillRemoveIt(t *testing.T) {
 	impInvoker := impression.NewImpressionInvoker(internalFlags, nil, nil, false)
 
 	flagSetter := NewFlagSetter(flagRepo, parser, expRepo, impInvoker)
-	flagRepo.AddFlag(NewFlag(false), "f2")
+	flagRepo.AddFlag(NewFlag(false), "f2", "f2")
 
 	expRepo.SetExperiments([]*model.ExperimentModel{
 		model.NewExperimentModel("id1", "1", "con", false, []string{"f2"}, nil),
@@ -103,7 +103,7 @@ func TestFlagSetterWillSetFlagWithoutExperimentAndThenAddExperiment(t *testing.T
 	impInvoker := impression.NewImpressionInvoker(internalFlags, nil, nil, false)
 
 	flagSetter := NewFlagSetter(flagRepo, parser, expRepo, impInvoker)
-	flagRepo.AddFlag(NewFlag(false), "f2")
+	flagRepo.AddFlag(NewFlag(false), "f2", "f2")
 	flagSetter.SetExperiments()
 
 	assert.Equal(t, "", flagRepo.GetFlag("f2").(internalVariant).Condition())
@@ -138,8 +138,8 @@ func TestFlagSetterWillSetDataForAddedFlag(t *testing.T) {
 	flagSetter := NewFlagSetter(flagRepo, parser, expRepo, impInvoker)
 	flagSetter.SetExperiments()
 
-	flagRepo.AddFlag(NewFlag(false), "f1")
-	flagRepo.AddFlag(NewFlag(false), "f2")
+	flagRepo.AddFlag(NewFlag(false), "f1", "f1")
+	flagRepo.AddFlag(NewFlag(false), "f2", "f2")
 
 	assert.Equal(t, "1", flagRepo.GetFlag("f1").(internalVariant).Condition())
 	assert.Equal(t, "", flagRepo.GetFlag("f2").(internalVariant).Condition())

--- a/v5/core/entities/roxDouble.go
+++ b/v5/core/entities/roxDouble.go
@@ -84,6 +84,10 @@ func (v *roxDouble) SetName(name string) {
 	v.name = name
 }
 
+func (v *roxDouble) SetTag(tag string) {
+	v.tag = tag
+}
+
 func (v *roxDouble) GetValueAsString(ctx context.Context) string {
 	return strconv.FormatFloat(v.GetValue(ctx), 'f', -1, 64)
 }

--- a/v5/core/entities/roxInt.go
+++ b/v5/core/entities/roxInt.go
@@ -84,6 +84,10 @@ func (v *roxInt) SetName(name string) {
 	v.name = name
 }
 
+func (v *roxInt) SetTag(tag string) {
+	v.tag = tag
+}
+
 func (v *roxInt) GetValueAsString(ctx context.Context) string {
 	return strconv.Itoa(v.GetValue(ctx))
 }

--- a/v5/core/entities/roxString.go
+++ b/v5/core/entities/roxString.go
@@ -84,6 +84,10 @@ func (v *roxString) SetName(name string) {
 	v.name = name
 }
 
+func (v *roxString) SetTag(tag string) {
+	v.tag = tag
+}
+
 func (v *roxString) GetValueAsString(ctx context.Context) string {
 	return v.GetValue(ctx)
 }

--- a/v5/core/entities/roxVariant.go
+++ b/v5/core/entities/roxVariant.go
@@ -3,10 +3,15 @@ package entities
 type roxVariant struct {
 	name     string
 	flagType int
+	tag      string
 }
 
 func (v *roxVariant) Name() string {
 	return v.name
+}
+
+func (v *roxVariant) Tag() string {
+	return v.tag
 }
 
 func (v *roxVariant) FlagType() int {

--- a/v5/core/extensions/experiments_extensions_test.go
+++ b/v5/core/extensions/experiments_extensions_test.go
@@ -86,7 +86,7 @@ func TestExperimentsExtensionsFlagValueFlagEvaluationDefault(t *testing.T) {
 	experimentsExtensions.Extend()
 
 	v := entities.NewRoxString("op1", []string{"op2"})
-	flagRepository.AddFlag(v, "f1")
+	flagRepository.AddFlag(v, "f1", "f1")
 
 	assert.Equal(t, "op1", parser.EvaluateExpression(`flagValue("f1")`, nil).Value())
 }
@@ -100,10 +100,10 @@ func TestExperimentsExtensionsFlagDependencyValue(t *testing.T) {
 	experimentsExtensions.Extend()
 
 	f := entities.NewFlag(false)
-	flagRepository.AddFlag(f, "f1")
+	flagRepository.AddFlag(f, "f1", "f1")
 
 	v := entities.NewRoxString("blue", []string{"red", "green"})
-	flagRepository.AddFlag(v, "v1")
+	flagRepository.AddFlag(v, "v1", "v1")
 	exp := model.NewExperimentModel("id", "name", `ifThen(eq("true", flagValue("f1")), "red", "green")`, false, nil, nil)
 	v.(model.InternalVariant).SetForEvaluation(parser, exp, nil)
 
@@ -121,11 +121,11 @@ func TestExperimentsExtensionsFlagDependencyImpressionHandler(t *testing.T) {
 	experimentsExtensions.Extend()
 
 	f := entities.NewFlag(false)
-	flagRepository.AddFlag(f, "f1")
+	flagRepository.AddFlag(f, "f1", "f1")
 	f.(model.InternalVariant).SetForEvaluation(parser, nil, ii)
 
 	v := entities.NewRoxString("blue", []string{"red", "green"})
-	flagRepository.AddFlag(v, "v1")
+	flagRepository.AddFlag(v, "v1", "v1")
 	exp := model.NewExperimentModel("id", "name", `ifThen(eq("true", flagValue("f1")), "red", "green")`, false, nil, nil)
 	v.(model.InternalVariant).SetForEvaluation(parser, exp, ii)
 
@@ -150,12 +150,12 @@ func TestExperimentsExtensionsFlagDependency2LevelsBottomNotExists(t *testing.T)
 	experimentsExtensions.Extend()
 
 	f := entities.NewFlag(false)
-	flagRepository.AddFlag(f, "f1")
+	flagRepository.AddFlag(f, "f1", "f1")
 	exp1 := model.NewExperimentModel("id1", "name1", `flagValue("someFlag")`, false, nil, nil)
 	f.(model.InternalVariant).SetForEvaluation(parser, exp1, nil)
 
 	v := entities.NewRoxString("blue", []string{"red", "green"})
-	flagRepository.AddFlag(v, "v1")
+	flagRepository.AddFlag(v, "v1", "f1")
 	exp2 := model.NewExperimentModel("id2", "name2", `ifThen(eq("true", flagValue("f1")), "red", "green")`, false, nil, nil)
 	v.(model.InternalVariant).SetForEvaluation(parser, exp2, nil)
 
@@ -182,7 +182,7 @@ func TestExperimentsExtensionsFlagDependencyUnexistingFlagButExistingExperiment(
 
 	colorVar := entities.NewRoxString("red", []string{"red", "green", "blue"})
 	colorVar.(model.InternalVariant).SetForEvaluation(parser, nil, nil)
-	flagRepository.AddFlag(colorVar, "colorVar")
+	flagRepository.AddFlag(colorVar, "colorVar", "colorVar")
 
 	assert.Equal(t, "blue", colorVar.GetValueAsString(nil))
 }
@@ -207,7 +207,7 @@ func TestExperimentsExtensionsFlagDependencyUnexistingFlagAndExperimentUndefined
 
 	colorVar := entities.NewRoxString("red", []string{"red", "green", "blue"})
 	colorVar.(model.InternalVariant).SetForEvaluation(parser, nil, nil)
-	flagRepository.AddFlag(colorVar, "colorVar")
+	flagRepository.AddFlag(colorVar, "colorVar", "colorVar")
 
 	assert.Equal(t, "green", colorVar.GetValueAsString(nil))
 }
@@ -229,12 +229,12 @@ func TestExperimentsExtensionsFlagDependencyWithContext(t *testing.T) {
 	flag1 := entities.NewFlag(false)
 	exp1 := model.NewExperimentModel("id1", "name1", `property("prop")`, false, nil, nil)
 	flag1.(model.InternalVariant).SetForEvaluation(parser, exp1, nil)
-	flagRepository.AddFlag(flag1, "flag1")
+	flagRepository.AddFlag(flag1, "flag1", "flag1")
 
 	flag2 := entities.NewFlag(false)
 	exp2 := model.NewExperimentModel("id2", "name2", `flagValue("flag1")`, false, nil, nil)
 	flag2.(model.InternalVariant).SetForEvaluation(parser, exp2, nil)
-	flagRepository.AddFlag(flag2, "flag2")
+	flagRepository.AddFlag(flag2, "flag2", "flag2")
 
 	flagValue := flag2.GetValueAsString(context.NewContext(map[string]interface{}{"isPropOn": true}))
 
@@ -258,7 +258,7 @@ func TestExperimentsExtensionsFlagDependencyWithContextUsedOnExperimentWithNoFla
 	flag3 := entities.NewFlag(false)
 	exp3 := model.NewExperimentModel("id3", "name3", `flagValue("flag2")`, false, nil, nil)
 	flag3.(model.InternalVariant).SetForEvaluation(parser, exp3, nil)
-	flagRepository.AddFlag(flag3, "flag3")
+	flagRepository.AddFlag(flag3, "flag3", "flag3")
 
 	experimentModels := []*model.ExperimentModel{
 		model.NewExperimentModel("exp1id", "exp1name", `property("prop")`, false, []string{"flag2"}, nil),
@@ -287,12 +287,12 @@ func TestExperimentsExtensionsFlagDependencyWithContext2LevelMidLevelNoFlagEvalE
 	flag1 := entities.NewFlag(false)
 	exp1 := model.NewExperimentModel("id1", "name1", `property("prop")`, false, nil, nil)
 	flag1.(model.InternalVariant).SetForEvaluation(parser, exp1, nil)
-	flagRepository.AddFlag(flag1, "flag1")
+	flagRepository.AddFlag(flag1, "flag1", "flag1")
 
 	flag3 := entities.NewFlag(false)
 	exp2 := model.NewExperimentModel("id3", "name3", `flagValue("flag2")`, false, nil, nil)
 	flag3.(model.InternalVariant).SetForEvaluation(parser, exp2, nil)
-	flagRepository.AddFlag(flag3, "flag3")
+	flagRepository.AddFlag(flag3, "flag3", "flag3")
 
 	experimentModels := []*model.ExperimentModel{
 		model.NewExperimentModel("exp1id", "exp1name", `flagValue("flag1")`, false, []string{"flag2"}, nil),

--- a/v5/core/mocks/flag_repository.go
+++ b/v5/core/mocks/flag_repository.go
@@ -9,8 +9,8 @@ type FlagRepository struct {
 	mock.Mock
 }
 
-func (m *FlagRepository) AddFlag(flag model.Variant, name string) {
-	m.Called(flag, name)
+func (m *FlagRepository) AddFlag(flag model.Variant, name string, tag string) {
+	m.Called(flag, name, tag)
 }
 
 func (m *FlagRepository) GetFlag(name string) model.Variant {

--- a/v5/core/model/entitites.go
+++ b/v5/core/model/entitites.go
@@ -8,6 +8,7 @@ import (
 type Variant interface {
 	Name() string
 	FlagType() int
+	Tag() string
 	GetValueAsString(context context.Context) string
 	GetDefaultAsString() string
 	GetOptionsAsString() []string
@@ -50,6 +51,7 @@ type EntitiesProvider interface {
 
 type InternalVariant interface {
 	SetName(name string)
+	SetTag(tag string)
 	SetContext(globalContext context.Context)
 	SetForEvaluation(parser roxx.Parser, experiment *ExperimentModel, impressionInvoker ImpressionInvoker)
 }

--- a/v5/core/model/repositories.go
+++ b/v5/core/model/repositories.go
@@ -21,7 +21,7 @@ type ExperimentRepository interface {
 type FlagAddedHandler = func(variant Variant)
 
 type FlagRepository interface {
-	AddFlag(roxFlag Variant, name string)
+	AddFlag(roxFlag Variant, name string, tag string)
 	GetFlag(name string) Variant
 	GetAllFlags() []Variant
 

--- a/v5/core/network/state_sender_test.go
+++ b/v5/core/network/state_sender_test.go
@@ -108,14 +108,14 @@ func TestWillCallOnlyCDNStateMD5ChangesForFlag(t *testing.T) {
 		requestData = args.Get(0).(model.RequestData)
 	})
 
-	flagRepo.AddFlag(entities.NewFlag(false), "flag1")
+	flagRepo.AddFlag(entities.NewFlag(false), "flag1", "flag1")
 	stateSender := NewStateSender(request, dp, flagRepo, cpRepo, environment)
 	stateSender.Send()
 
 	assert.Equal(t, fmt.Sprintf("%s/%s/%s", consts.EnvironmentStateCDNPath(), appKey, "C1C65A5AC8A732EAB7FCD81017BF5A87"), requestData.URL)
 	request.AssertNumberOfCalls(t, "SendGet", 1)
 
-	flagRepo.AddFlag(entities.NewFlag(false), "flag2")
+	flagRepo.AddFlag(entities.NewFlag(false), "flag2", "flag2")
 	stateSender.Send()
 	assert.Equal(t, fmt.Sprintf("%s/%s/%s", consts.EnvironmentStateCDNPath(), appKey, "F367809AB0CCA5A05EA9DFB3C4E9E15C"), requestData.URL)
 }
@@ -160,8 +160,8 @@ func TestWillCallOnlyCDNStateMD5FlagOrderNotImportant(t *testing.T) {
 		requestData = args.Get(0).(model.RequestData)
 	})
 
-	flagRepo.AddFlag(entities.NewFlag(false), "flag1")
-	flagRepo.AddFlag(entities.NewFlag(false), "flag2")
+	flagRepo.AddFlag(entities.NewFlag(false), "flag1", "flag1")
+	flagRepo.AddFlag(entities.NewFlag(false), "flag2", "flag2")
 	stateSender := NewStateSender(request, dp, flagRepo, cpRepo, environment)
 	stateSender.Send()
 
@@ -169,8 +169,8 @@ func TestWillCallOnlyCDNStateMD5FlagOrderNotImportant(t *testing.T) {
 	request.AssertNumberOfCalls(t, "SendGet", 1)
 
 	flagRepo2 := repositories.NewFlagRepository()
-	flagRepo2.AddFlag(entities.NewFlag(false), "flag2")
-	flagRepo2.AddFlag(entities.NewFlag(false), "flag1")
+	flagRepo2.AddFlag(entities.NewFlag(false), "flag2", "flag2")
+	flagRepo2.AddFlag(entities.NewFlag(false), "flag1", "flag1")
 	stateSender = NewStateSender(request, dp, flagRepo2, cpRepo, environment)
 	stateSender.Send()
 	assert.Equal(t, fmt.Sprintf("%s/%s/%s", consts.EnvironmentStateCDNPath(), appKey, "F367809AB0CCA5A05EA9DFB3C4E9E15C"), requestData.URL)
@@ -223,7 +223,7 @@ func TestWillReturnNullWhenCDNFailsWithException(t *testing.T) {
 		reqAPIData = args.Get(0).(model.RequestData)
 	})
 
-	flagRepo.AddFlag(entities.NewFlag(false), "flag")
+	flagRepo.AddFlag(entities.NewFlag(false), "flag", "flag")
 	stateSender := NewStateSender(request, dp, flagRepo, cpRepo, environment)
 	stateSender.Send()
 
@@ -251,7 +251,7 @@ func TestWillReturnNullWhenCDNSucceedWithEmptyResponse(t *testing.T) {
 		reqAPIData = args.Get(0).(string)
 	})
 
-	flagRepo.AddFlag(entities.NewFlag(false), "flag")
+	flagRepo.AddFlag(entities.NewFlag(false), "flag", "flag")
 	stateSender := NewStateSender(request, dp, flagRepo, cpRepo, environment)
 	stateSender.Send()
 
@@ -279,7 +279,7 @@ func TestWillReturnNullWhenCDNSucceedWithNotJsonResponse(t *testing.T) {
 		reqAPIData = args.Get(0).(string)
 	})
 
-	flagRepo.AddFlag(entities.NewFlag(false), "flag")
+	flagRepo.AddFlag(entities.NewFlag(false), "flag", "flag")
 	stateSender := NewStateSender(request, dp, flagRepo, cpRepo, environment)
 	stateSender.Send()
 
@@ -307,7 +307,7 @@ func TestWillReturnNullWhenCDNFails404APIWithException(t *testing.T) {
 		reqAPIData = args.Get(0).(string)
 	})
 
-	flagRepo.AddFlag(entities.NewFlag(false), "flag")
+	flagRepo.AddFlag(entities.NewFlag(false), "flag", "flag")
 	cpRepo.AddCustomProperty(properties.NewStringProperty("id", "1111"))
 	stateSender := NewStateSender(request, dp, flagRepo, cpRepo, environment)
 	stateSender.Send()
@@ -336,7 +336,7 @@ func TestWillReturnAPIDataWhenCDNSucceedWithResult404APIOK(t *testing.T) {
 		reqAPIData = args.Get(0).(string)
 	})
 
-	flagRepo.AddFlag(entities.NewFlag(false), "flag")
+	flagRepo.AddFlag(entities.NewFlag(false), "flag", "flag")
 	cpRepo.AddCustomProperty(properties.NewStringProperty("id", "1111"))
 	stateSender := NewStateSender(request, dp, flagRepo, cpRepo, environment)
 	stateSender.Send()
@@ -365,7 +365,7 @@ func TestWillReturnAPIDataWhenWhenSelfManaged(t *testing.T) {
 		reqAPIData = args.Get(0).(string)
 	})
 
-	flagRepo.AddFlag(entities.NewFlag(false), "flag")
+	flagRepo.AddFlag(entities.NewFlag(false), "flag", "flag")
 	cpRepo.AddCustomProperty(properties.NewStringProperty("id", "1111"))
 	stateSender := NewStateSender(request, dp, flagRepo, cpRepo, environment)
 	stateSender.Send()

--- a/v5/core/register/register_test.go
+++ b/v5/core/register/register_test.go
@@ -18,6 +18,46 @@ type Container1 struct {
 	SomethingElse interface{}
 }
 
+type Container2 struct {
+	Variant1 model.Variant `fflag:"variant-1"`
+	Flag1    model.Flag    `fflag:"flag.long.name"`
+	Flag2    model.Flag    `fflag:"flag-2"`
+	Flag3    model.Flag    `fflag:"flag_3"`
+
+	SomethingElse interface{} `fflag:"something_else"`
+}
+
+func TestRegisterWillSetTagsIfAvailable(t *testing.T) {
+	flagRepo := repositories.NewFlagRepository()
+	container2 := &Container2{
+		Variant1:      entities.NewRoxString("1", []string{"1", "2", "3"}),
+		Flag1:         entities.NewFlag(false),
+		Flag2:         entities.NewFlag(false),
+		Flag3:         entities.NewFlag(false),
+		SomethingElse: struct{}{},
+	}
+	registerer := register.NewRegisterer(flagRepo)
+	registerer.RegisterInstance(container2, "ns1")
+
+	assert.Equal(t, "ns1.variant-1", flagRepo.GetFlag("ns1.Variant1").Tag())
+}
+
+func TestRegisterWillSetTagToNameIfTagsNotFound(t *testing.T) {
+	flagRepo := repositories.NewFlagRepository()
+
+	container1 := &Container1{
+		Variant1:      entities.NewRoxString("1", []string{"1", "2", "3"}),
+		Flag1:         entities.NewFlag(false),
+		Flag2:         entities.NewFlag(false),
+		Flag3:         entities.NewFlag(false),
+		SomethingElse: struct{}{},
+	}
+	registerer := register.NewRegisterer(flagRepo)
+	registerer.RegisterInstance(container1, "ns1")
+
+	assert.Equal(t, "ns1.Variant1", flagRepo.GetFlag("ns1.Variant1").Tag())
+}
+
 func TestRegistererWillThrowWhenNSRegisteredTwice(t *testing.T) {
 	flagRepo := repositories.NewFlagRepository()
 	container := &Container1{

--- a/v5/core/register/registerer.go
+++ b/v5/core/register/registerer.go
@@ -7,6 +7,9 @@ import (
 	"sync"
 )
 
+//The name of the tag we use to set the actual flag name in flag structs
+const flagStructTagName = "fflag"
+
 type Registerer struct {
 	flagRepository model.FlagRepository
 	namespaces     map[string]bool
@@ -41,10 +44,18 @@ func (r *Registerer) RegisterInstance(container interface{}, ns string) {
 		}
 
 		name := v.Type().Field(i).Name
-		if ns != "" {
-			name = fmt.Sprintf("%s.%s", ns, name)
+		//check for our tag in struct definition
+		tag := v.Type().Field(i).Tag.Get(flagStructTagName)
+		if tag == "" {
+			//always set the tag
+			tag = name
 		}
 
-		r.flagRepository.AddFlag(variant, name)
+		if ns != "" {
+			name = fmt.Sprintf("%s.%s", ns, name)
+			tag = fmt.Sprintf("%s.%s", ns, tag)
+		}
+
+		r.flagRepository.AddFlag(variant, name, tag)
 	}
 }

--- a/v5/core/repositories/flag_repository.go
+++ b/v5/core/repositories/flag_repository.go
@@ -20,10 +20,11 @@ func NewFlagRepository() model.FlagRepository {
 	}
 }
 
-func (r *flagRepository) AddFlag(variant model.Variant, name string) {
+func (r *flagRepository) AddFlag(variant model.Variant, name string, tag string) {
 	if variant.(model.Variant).Name() == "" {
 		variant.(model.InternalVariant).SetName(name)
 	}
+	variant.(model.InternalVariant).SetTag(tag)
 
 	r.mutex.Lock()
 	r.variants[name] = variant

--- a/v5/core/repositories/flag_repository_test.go
+++ b/v5/core/repositories/flag_repository_test.go
@@ -17,7 +17,7 @@ func TestFlagRepositoryWillReturnNullWhenFlagNotFound(t *testing.T) {
 func TestFlagRepositoryWillAddFlagAndSetName(t *testing.T) {
 	repo := repositories.NewFlagRepository()
 	flag := entities.NewFlag(false)
-	repo.AddFlag(flag, "harti")
+	repo.AddFlag(flag, "harti", "harti")
 
 	assert.Equal(t, "harti", repo.GetFlag("harti").Name())
 }
@@ -25,7 +25,7 @@ func TestFlagRepositoryWillAddFlagAndSetName(t *testing.T) {
 func TestFlagRepositoryWillAddRoxStringAndSetName(t *testing.T) {
 	repo := repositories.NewFlagRepository()
 	flag := entities.NewRoxString("1", []string{"2", "3"})
-	repo.AddFlag(flag, "harti")
+	repo.AddFlag(flag, "harti", "harti")
 
 	assert.Equal(t, "harti", repo.GetFlag("harti").Name())
 }
@@ -33,7 +33,7 @@ func TestFlagRepositoryWillAddRoxStringAndSetName(t *testing.T) {
 func TestFlagRepositoryWillAddRoxIntAndSetName(t *testing.T) {
 	repo := repositories.NewFlagRepository()
 	flag := entities.NewRoxInt(1, []int{2, 3})
-	repo.AddFlag(flag, "harti")
+	repo.AddFlag(flag, "harti", "harti")
 
 	assert.Equal(t, "harti", repo.GetFlag("harti").Name())
 }
@@ -47,7 +47,7 @@ func TestFlagRepositoryWillRaiseFlagAddedEvent(t *testing.T) {
 		variantFromEvent = variant
 	})
 
-	repo.AddFlag(flag, "harti")
+	repo.AddFlag(flag, "harti", "harti")
 
 	assert.Equal(t, "harti", variantFromEvent.Name())
 }
@@ -62,7 +62,7 @@ func TestFlagRepositoryRecoversFromPanic(t *testing.T) {
 		panic("mwahahahaha evil user")
 	})
 
-	repo.AddFlag(flag, "harti")
+	repo.AddFlag(flag, "harti", "harti")
 
 	assert.Equal(t, "harti", variantFromEvent.Name())
 }

--- a/v5/go.mod
+++ b/v5/go.mod
@@ -4,18 +4,23 @@ go 1.14
 
 require (
 	github.com/go-errors/errors v1.2.0
-	github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 // indirect
 	github.com/hashicorp/go-version v1.3.0
-	github.com/kr/text v0.2.0 // indirect
 	github.com/magiconair/properties v1.8.4
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/rollout/sse v0.0.0-20181105093643-e422b54b3b28
 	github.com/satori/go.uuid v1.2.1-0.20180103174451-36e9d2ebbde5
+	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/smartystreets/assertions v1.2.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
-	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed // indirect
 	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect


### PR DESCRIPTION
This adds the ability to set a flag name (tag) if there is an annotated struct. This is a partial step towards the ability to use real flag names, unrestricted by Go.  I cannot see where the 'getting' from the service of a flag value is done, as there are no tests to get intuition from.  However, I've amended tests as required and added new tests to show that Tag is a thing. I need help to get your service to use the tag values as the flag names.