### PR TITLE
allowing tags as alternative flag names (static api - container)

### DIFF
--- a/v5/core/client/device_properties.go
+++ b/v5/core/client/device_properties.go
@@ -41,7 +41,7 @@ func (*deviceProperties) RolloutEnvironment() string {
 }
 
 func (*deviceProperties) LibVersion() string {
-	return "5.0.3"
+	return "5.0.4"
 }
 
 func (dp *deviceProperties) RolloutKey() string {

--- a/v5/core/register/register_test.go
+++ b/v5/core/register/register_test.go
@@ -18,6 +18,15 @@ type Container1 struct {
 	SomethingElse interface{}
 }
 
+type Container2 struct {
+	Variant1 model.Variant `flagName:"variant-1"`
+	Flag1    model.Flag    `flagName:"flag.long.name"`
+	Flag2    model.Flag    `otherTag:"flag-2"`
+	Flag3    model.Flag    `flagName:"flag_3"`
+
+	SomethingElse interface{} `flagName:"something_else"`
+}
+
 func TestRegistererWillThrowWhenNSRegisteredTwice(t *testing.T) {
 	flagRepo := repositories.NewFlagRepository()
 	container := &Container1{
@@ -68,4 +77,38 @@ func TestRegistererWillRegisterWithEmptyNS(t *testing.T) {
 	assert.Equal(t, 4, len(flagRepo.GetAllFlags()))
 	assert.Equal(t, "1", flagRepo.GetFlag("Variant1").GetDefaultAsString())
 	assert.Equal(t, "false", flagRepo.GetFlag("Flag1").GetDefaultAsString())
+}
+
+func TestRegisterWillSetNameFromTagIfAvailable(t *testing.T) {
+	flagRepo := repositories.NewFlagRepository()
+	container2 := &Container2{
+		Variant1:      entities.NewRoxString("1", []string{"1", "2", "3"}),
+		Flag1:         entities.NewFlag(false),
+		Flag2:         entities.NewFlag(false),
+		Flag3:         entities.NewFlag(false),
+		SomethingElse: struct{}{},
+	}
+	registerer := register.NewRegisterer(flagRepo)
+	registerer.RegisterInstance(container2, "ns1")
+
+	assert.Equal(t, "ns1.variant-1", flagRepo.GetFlag("ns1.variant-1").Name())
+}
+
+func TestRegisterWillUseVariableNameIgnoringOtherTags(t *testing.T) {
+	flagRepo := repositories.NewFlagRepository()
+
+	container2 := &Container2{
+		Variant1:      entities.NewRoxString("1", []string{"1", "2", "3"}),
+		Flag1:         entities.NewFlag(false),
+		Flag2:         entities.NewFlag(false),
+		Flag3:         entities.NewFlag(false),
+		SomethingElse: struct{}{},
+	}
+	registerer := register.NewRegisterer(flagRepo)
+	registerer.RegisterInstance(container2, "ns1")
+	
+	flag := flagRepo.GetFlag("ns1.flag-2")
+	assert.Equal(t, nil, flag, "flag was wrongly registered with unrecognized tag")
+
+	assert.Equal(t, "ns1.Flag2", flagRepo.GetFlag("ns1.Flag2").Name())
 }

--- a/v5/core/repositories/flag_repository.go
+++ b/v5/core/repositories/flag_repository.go
@@ -1,9 +1,10 @@
 package repositories
 
 import (
+	"sync"
+
 	"github.com/rollout/rox-go/v5/core/logging"
 	"github.com/rollout/rox-go/v5/core/model"
-	"sync"
 )
 
 type flagRepository struct {


### PR DESCRIPTION
This will replace the name
so the container will have a field flag1. ex: flags.flag1.isEnabled()
but impressionHandler, Dashboard, dynamicApi and everywhere else the tag will be used instead (there will be no way to trace back the flag variable from the flag name)

NOTE: setting the tag flagName to an already used flag will break the value (as it will be a completely different flag network wise)

this is done to solve flag name limitation (variables in Go) and multiplatform, when we might use the same name in other programming languages