### PR TITLE
adding network configurations to roxOptions

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -35,7 +35,7 @@ jobs:
         working-directory: ./sdk-end-2-end-tests
         run: |
           yarn install --frozen-lockfile
-          QA_E2E_BEARER=$QA_E2E_BEARER SDK_LANG=go NODE_ENV=qa yarn test
+          QA_E2E_BEARER=$TEST_E2E_BEARER API_HOST=https://api.test.rollout.io CD_API_ENDPOINT=https://api.test.rollout.io/device/get_configuration CD_S3_ENDPOINT=https://rox-conf.test.rollout.io/ SS_API_ENDPOINT=https://api.test.rollout.io/device/update_state_store/ SS_S3_ENDPOINT=https://rox-state.test.rollout.io/ CLIENT_DATA_CACHE_KEY=client_data ANALYTICS_ENDPOINT=https://analytic.test.rollout.io/ NOTIFICATIONS_ENDPOINT=https://push.test.rollout.io/sse SDK_LANG=go NODE_ENV=container yarn test:env
         env:
           QA_E2E_BEARER: ${{ secrets.QA_E2E_BEARER }}
 #          TODO: implement EU hosting support

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -35,7 +35,7 @@ jobs:
         working-directory: ./sdk-end-2-end-tests
         run: |
           yarn install --frozen-lockfile
-          QA_E2E_BEARER=$TEST_E2E_BEARER API_HOST=https://api.test.rollout.io CD_API_ENDPOINT=https://api.test.rollout.io/device/get_configuration CD_S3_ENDPOINT=https://rox-conf.test.rollout.io/ SS_API_ENDPOINT=https://api.test.rollout.io/device/update_state_store/ SS_S3_ENDPOINT=https://rox-state.test.rollout.io/ CLIENT_DATA_CACHE_KEY=client_data ANALYTICS_ENDPOINT=https://analytic.test.rollout.io/ NOTIFICATIONS_ENDPOINT=https://push.test.rollout.io/sse SDK_LANG=go NODE_ENV=container yarn test:env
+          QA_E2E_BEARER=$QA_E2E_BEARER API_HOST=https://api.test.rollout.io CD_API_ENDPOINT=https://api.test.rollout.io/device/get_configuration CD_S3_ENDPOINT=https://rox-conf.test.rollout.io/ SS_API_ENDPOINT=https://api.test.rollout.io/device/update_state_store/ SS_S3_ENDPOINT=https://rox-state.test.rollout.io/ CLIENT_DATA_CACHE_KEY=client_data ANALYTICS_ENDPOINT=https://analytic.test.rollout.io/ NOTIFICATIONS_ENDPOINT=https://push.test.rollout.io/sse SDK_LANG=go NODE_ENV=container yarn test:env
         env:
           QA_E2E_BEARER: ${{ secrets.QA_E2E_BEARER }}
 #          TODO: implement EU hosting support

--- a/v5/core/client/custom_environmet.go
+++ b/v5/core/client/custom_environmet.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rollout/rox-go/v5/core/model"
 )
 
-type CustomSaasEnvironment struct{
+type CustomEnvironment struct{
 	getConfigApiURL string
 	getConfigCloudURL string
 	sendStateApiURL string
@@ -22,8 +22,8 @@ func TrimSuffix(s, suffix string) string {
     return s
 }
 
-func NewCustomSaasEnvironment(options model.NetworkConfigurationsOptions) CustomSaasEnvironment {
-	return CustomSaasEnvironment{
+func NewCustomEnvironment(options model.NetworkConfigurationsOptions) CustomEnvironment {
+	return CustomEnvironment{
 		getConfigApiURL:    TrimSuffix(options.GetConfigApiEndpoint(), "/"),
 		getConfigCloudURL: 	TrimSuffix(options.GetConfigCloudEndpoint(), "/"),
 		sendStateApiURL: 	TrimSuffix(options.SendStateApiEndpoint(), "/"),
@@ -33,34 +33,34 @@ func NewCustomSaasEnvironment(options model.NetworkConfigurationsOptions) Custom
 	}
 }
 
-func (e CustomSaasEnvironment) EnvironmentRoxyInternalPath() string {
+func (e CustomEnvironment) EnvironmentRoxyInternalPath() string {
 	return "device/request_configuration"
 }
 
-func (e CustomSaasEnvironment) EnvironmentCDNPath() string {
+func (e CustomEnvironment) EnvironmentCDNPath() string {
 	return e.getConfigCloudURL
 }
 
-func (e CustomSaasEnvironment) EnvironmentAPIPath() string {
+func (e CustomEnvironment) EnvironmentAPIPath() string {
 	return e.getConfigApiURL
 }
 
-func (e CustomSaasEnvironment) EnvironmentStateCDNPath() string {
+func (e CustomEnvironment) EnvironmentStateCDNPath() string {
 	return e.sendStateCloudURL
 }
 
-func (e CustomSaasEnvironment) EnvironmentStateAPIPath() string {
+func (e CustomEnvironment) EnvironmentStateAPIPath() string {
 	return e.sendStateApiURL
 }
 
-func (e CustomSaasEnvironment) EnvironmentAnalyticsPath() string {
+func (e CustomEnvironment) EnvironmentAnalyticsPath() string {
 	return e.analyticsURL
 }
 
-func (e CustomSaasEnvironment) EnvironmentNotificationsPath() string {
+func (e CustomEnvironment) EnvironmentNotificationsPath() string {
 	return e.pushNotificationURL
 }
 
-func (e CustomSaasEnvironment) IsSelfManaged() bool {
+func (e CustomEnvironment) IsSelfManaged() bool {
 	return false
 }

--- a/v5/core/client/custom_saas_environmet.go
+++ b/v5/core/client/custom_saas_environmet.go
@@ -1,0 +1,66 @@
+package client
+
+import (
+	"strings"
+
+	"github.com/rollout/rox-go/v5/core/model"
+)
+
+type CustomSaasEnvironment struct{
+	getConfigApiURL string
+	getConfigCloudURL string
+	sendStateApiURL string
+	sendStateCloudURL string
+	analyticsURL string
+	pushNotificationURL string
+}
+
+func TrimSuffix(s, suffix string) string {
+    if strings.HasSuffix(s, suffix) {
+        s = s[:len(s)-len(suffix)]
+    }
+    return s
+}
+
+func NewCustomSaasEnvironment(options model.NetworkConfigurationsOptions) CustomSaasEnvironment {
+	return CustomSaasEnvironment{
+		getConfigApiURL:    TrimSuffix(options.GetConfigApiEndpoint(), "/"),
+		getConfigCloudURL: 	TrimSuffix(options.GetConfigCloudEndpoint(), "/"),
+		sendStateApiURL: 	TrimSuffix(options.SendStateApiEndpoint(), "/"),
+		sendStateCloudURL: 	TrimSuffix(options.SendStateCloudEndpoint(), "/"),
+		analyticsURL: 		TrimSuffix(options.AnalyticsEndpoint(), "/"),
+		pushNotificationURL:TrimSuffix(options.PushNotificationEndpoint(), "/"),
+	}
+}
+
+func (e CustomSaasEnvironment) EnvironmentRoxyInternalPath() string {
+	return "device/request_configuration"
+}
+
+func (e CustomSaasEnvironment) EnvironmentCDNPath() string {
+	return e.getConfigCloudURL
+}
+
+func (e CustomSaasEnvironment) EnvironmentAPIPath() string {
+	return e.getConfigApiURL
+}
+
+func (e CustomSaasEnvironment) EnvironmentStateCDNPath() string {
+	return e.sendStateCloudURL
+}
+
+func (e CustomSaasEnvironment) EnvironmentStateAPIPath() string {
+	return e.sendStateApiURL
+}
+
+func (e CustomSaasEnvironment) EnvironmentAnalyticsPath() string {
+	return e.analyticsURL
+}
+
+func (e CustomSaasEnvironment) EnvironmentNotificationsPath() string {
+	return e.pushNotificationURL
+}
+
+func (e CustomSaasEnvironment) IsSelfManaged() bool {
+	return false
+}

--- a/v5/core/client/device_properties.go
+++ b/v5/core/client/device_properties.go
@@ -41,7 +41,7 @@ func (*deviceProperties) RolloutEnvironment() string {
 }
 
 func (*deviceProperties) LibVersion() string {
-	return "5.0.2"
+	return "5.0.3"
 }
 
 func (dp *deviceProperties) RolloutKey() string {

--- a/v5/core/client/network_configurations_options.go
+++ b/v5/core/client/network_configurations_options.go
@@ -1,0 +1,56 @@
+package client
+
+import "github.com/rollout/rox-go/v5/core/model"
+
+type NetworkConfigurationsBuilder struct {
+	GetConfigApiEndpoint string
+	GetConfigCloudEndpoint string
+	SendStateApiEndpoint string
+	SendStateCloudEndpoint string
+	AnalyticsEndpoint string
+	PushNotificationEndpoint string
+}
+
+type NetworkConfigurations struct {
+	getConfigApiEndpoint string
+	getConfigCloudEndpoint string
+	sendStateApiEndpoint string
+	sendStateCloudEndpoint string
+	analyticsEndpoint string
+	pushNotificationEndpoint string
+}
+
+func NewNetworkConfigurationsOptions(builder NetworkConfigurationsBuilder) model.NetworkConfigurationsOptions {
+	return NetworkConfigurations{
+		getConfigApiEndpoint: builder.GetConfigApiEndpoint,
+		getConfigCloudEndpoint: builder.GetConfigCloudEndpoint,
+		sendStateApiEndpoint: builder.SendStateApiEndpoint,
+		sendStateCloudEndpoint: builder.SendStateCloudEndpoint,
+		analyticsEndpoint: builder.AnalyticsEndpoint,
+		pushNotificationEndpoint: builder.PushNotificationEndpoint,
+	}
+}
+
+func (s NetworkConfigurations) GetConfigApiEndpoint() string {
+	return s.getConfigApiEndpoint
+}
+
+func (s NetworkConfigurations) GetConfigCloudEndpoint() string {
+	return s.getConfigCloudEndpoint
+}
+
+func (s NetworkConfigurations) SendStateApiEndpoint() string {
+	return s.sendStateApiEndpoint
+}
+
+func (s NetworkConfigurations) SendStateCloudEndpoint() string {
+	return s.sendStateCloudEndpoint
+}
+
+func (s NetworkConfigurations) AnalyticsEndpoint() string {
+	return s.analyticsEndpoint
+}
+
+func (s NetworkConfigurations) PushNotificationEndpoint() string {
+	return s.pushNotificationEndpoint
+}

--- a/v5/core/core.go
+++ b/v5/core/core.go
@@ -84,7 +84,7 @@ func (core *Core) Setup(sdkSettings model.SdkSettings, deviceProperties model.De
 	if roxOptions != nil && roxOptions.SelfManagedOptions() != nil {
 		core.environment = client.NewSelfManagedEnvironment(roxOptions.SelfManagedOptions())
 	} else if roxOptions != nil && roxOptions.NetworkConfigurationsOptions() != nil {
-		core.environment = client.NewCustomSaasEnvironment(roxOptions.NetworkConfigurationsOptions())
+		core.environment = client.NewCustomEnvironment(roxOptions.NetworkConfigurationsOptions())
 	} else {
 		core.environment = client.NewSaasEnvironment()
 	}

--- a/v5/core/core.go
+++ b/v5/core/core.go
@@ -1,9 +1,10 @@
 package core
 
 import (
-	"github.com/rollout/rox-go/v5/core/security"
 	"net/http"
 	"regexp"
+
+	"github.com/rollout/rox-go/v5/core/security"
 
 	"github.com/rollout/rox-go/v5/core/client"
 	"github.com/rollout/rox-go/v5/core/configuration"
@@ -82,6 +83,8 @@ func (core *Core) Setup(sdkSettings model.SdkSettings, deviceProperties model.De
 
 	if roxOptions != nil && roxOptions.SelfManagedOptions() != nil {
 		core.environment = client.NewSelfManagedEnvironment(roxOptions.SelfManagedOptions())
+	} else if roxOptions != nil && roxOptions.NetworkConfigurationsOptions() != nil {
+		core.environment = client.NewCustomSaasEnvironment(roxOptions.NetworkConfigurationsOptions())
 	} else {
 		core.environment = client.NewSaasEnvironment()
 	}

--- a/v5/core/mocks/rox_options.go
+++ b/v5/core/mocks/rox_options.go
@@ -67,3 +67,7 @@ func (m *RoxOptions) DynamicPropertyRuleHandler() model.DynamicPropertyRuleHandl
 	}
 	return result.(model.DynamicPropertyRuleHandler)
 }
+
+func (m *RoxOptions) NetworkConfigurationsOptions() model.NetworkConfigurationsOptions {
+	return nil
+}

--- a/v5/core/model/client.go
+++ b/v5/core/model/client.go
@@ -2,8 +2,9 @@ package model
 
 import (
 	"fmt"
-	"github.com/rollout/rox-go/v5/core/context"
 	"time"
+
+	"github.com/rollout/rox-go/v5/core/context"
 )
 
 type BUID interface {
@@ -25,6 +26,15 @@ type SelfManagedOptions interface {
 	AnalyticsURL() string
 }
 
+type NetworkConfigurationsOptions interface {
+	GetConfigApiEndpoint() string
+	GetConfigCloudEndpoint() string
+	SendStateApiEndpoint() string
+	SendStateCloudEndpoint() string
+	AnalyticsEndpoint() string
+	PushNotificationEndpoint() string
+}
+
 type RoxOptions interface {
 	DevModeKey() string
 	Version() string
@@ -34,6 +44,7 @@ type RoxOptions interface {
 	RoxyURL() string
 	SelfManagedOptions() SelfManagedOptions
 	DynamicPropertyRuleHandler() DynamicPropertyRuleHandler
+	NetworkConfigurationsOptions() NetworkConfigurationsOptions
 }
 
 type SdkSettings interface {

--- a/v5/server/rox_options.go
+++ b/v5/server/rox_options.go
@@ -1,32 +1,35 @@
 package server
 
 import (
+	"time"
+
 	"github.com/rollout/rox-go/v5/core/logging"
 	"github.com/rollout/rox-go/v5/core/model"
-	"time"
 )
 
 type RoxOptionsBuilder struct {
-	Version                     string
-	DevModeKey                  string
-	FetchInterval               time.Duration
-	Logger                      logging.Logger
-	ImpressionHandler           model.ImpressionHandler
-	ConfigurationFetchedHandler model.ConfigurationFetchedHandler
-	RoxyURL                     string
-	SelfManagedOptions          model.SelfManagedOptions
-	DynamicPropertyRuleHandler  model.DynamicPropertyRuleHandler
+	Version                     	string
+	DevModeKey                  	string
+	FetchInterval               	time.Duration
+	Logger                      	logging.Logger
+	ImpressionHandler           	model.ImpressionHandler
+	ConfigurationFetchedHandler 	model.ConfigurationFetchedHandler
+	RoxyURL                     	string
+	SelfManagedOptions          	model.SelfManagedOptions
+	DynamicPropertyRuleHandler  	model.DynamicPropertyRuleHandler
+	NetworkConfigurationsOptions	model.NetworkConfigurationsOptions
 }
 
 type roxOptions struct {
-	version                     string
-	devModeKey                  string
-	fetchInterval               time.Duration
-	impressionHandler           model.ImpressionHandler
-	configurationFetchedHandler model.ConfigurationFetchedHandler
-	roxyURL                     string
-	selfManagedOptions          model.SelfManagedOptions
-	dynamicPropertyRuleHandler  model.DynamicPropertyRuleHandler
+	version							string
+	devModeKey						string
+	fetchInterval					time.Duration
+	impressionHandler				model.ImpressionHandler
+	configurationFetchedHandler		model.ConfigurationFetchedHandler
+	roxyURL							string
+	selfManagedOptions				model.SelfManagedOptions
+	dynamicPropertyRuleHandler		model.DynamicPropertyRuleHandler
+	networkConfigurationsOptions	model.NetworkConfigurationsOptions
 }
 
 func NewRoxOptions(builder RoxOptionsBuilder) model.RoxOptions {
@@ -66,14 +69,15 @@ func NewRoxOptions(builder RoxOptionsBuilder) model.RoxOptions {
 	}
 
 	return &roxOptions{
-		version:                     version,
-		devModeKey:                  devModeKey,
-		fetchInterval:               fetchInterval,
-		impressionHandler:           builder.ImpressionHandler,
-		configurationFetchedHandler: builder.ConfigurationFetchedHandler,
-		roxyURL:                     builder.RoxyURL,
-		selfManagedOptions:          builder.SelfManagedOptions,
-		dynamicPropertyRuleHandler:  dynamicPropertyRuleHandler,
+		version:                     	version,
+		devModeKey:                  	devModeKey,
+		fetchInterval:               	fetchInterval,
+		impressionHandler:           	builder.ImpressionHandler,
+		configurationFetchedHandler: 	builder.ConfigurationFetchedHandler,
+		roxyURL:                     	builder.RoxyURL,
+		selfManagedOptions:          	builder.SelfManagedOptions,
+		dynamicPropertyRuleHandler:  	dynamicPropertyRuleHandler,
+		networkConfigurationsOptions:	builder.NetworkConfigurationsOptions,
 	}
 }
 
@@ -107,4 +111,8 @@ func (ro *roxOptions) SelfManagedOptions() model.SelfManagedOptions {
 
 func (ro *roxOptions) DynamicPropertyRuleHandler() model.DynamicPropertyRuleHandler {
 	return ro.dynamicPropertyRuleHandler
+}
+
+func (ro *roxOptions) NetworkConfigurationsOptions() model.NetworkConfigurationsOptions {
+	return ro.networkConfigurationsOptions
 }

--- a/v5/server/rox_options.go
+++ b/v5/server/rox_options.go
@@ -21,14 +21,14 @@ type RoxOptionsBuilder struct {
 }
 
 type roxOptions struct {
-	version							string
-	devModeKey						string
-	fetchInterval					time.Duration
-	impressionHandler				model.ImpressionHandler
-	configurationFetchedHandler		model.ConfigurationFetchedHandler
-	roxyURL							string
-	selfManagedOptions				model.SelfManagedOptions
-	dynamicPropertyRuleHandler		model.DynamicPropertyRuleHandler
+	version				string
+	devModeKey			string
+	fetchInterval			time.Duration
+	impressionHandler		model.ImpressionHandler
+	configurationFetchedHandler	model.ConfigurationFetchedHandler
+	roxyURL				string
+	selfManagedOptions		model.SelfManagedOptions
+	dynamicPropertyRuleHandler	model.DynamicPropertyRuleHandler
 	networkConfigurationsOptions	model.NetworkConfigurationsOptions
 }
 

--- a/v5/server/rox_options.go
+++ b/v5/server/rox_options.go
@@ -8,28 +8,28 @@ import (
 )
 
 type RoxOptionsBuilder struct {
-	Version                     	string
-	DevModeKey                  	string
-	FetchInterval               	time.Duration
-	Logger                      	logging.Logger
-	ImpressionHandler           	model.ImpressionHandler
-	ConfigurationFetchedHandler 	model.ConfigurationFetchedHandler
-	RoxyURL                     	string
-	SelfManagedOptions          	model.SelfManagedOptions
-	DynamicPropertyRuleHandler  	model.DynamicPropertyRuleHandler
-	NetworkConfigurationsOptions	model.NetworkConfigurationsOptions
+	Version                      string
+	DevModeKey                   string
+	FetchInterval                time.Duration
+	Logger                       logging.Logger
+	ImpressionHandler            model.ImpressionHandler
+	ConfigurationFetchedHandler  model.ConfigurationFetchedHandler
+	RoxyURL                      string
+	SelfManagedOptions           model.SelfManagedOptions
+	DynamicPropertyRuleHandler   model.DynamicPropertyRuleHandler
+	NetworkConfigurationsOptions model.NetworkConfigurationsOptions
 }
 
 type roxOptions struct {
-	version				string
-	devModeKey			string
-	fetchInterval			time.Duration
-	impressionHandler		model.ImpressionHandler
-	configurationFetchedHandler	model.ConfigurationFetchedHandler
-	roxyURL				string
-	selfManagedOptions		model.SelfManagedOptions
-	dynamicPropertyRuleHandler	model.DynamicPropertyRuleHandler
-	networkConfigurationsOptions	model.NetworkConfigurationsOptions
+	version                      string
+	devModeKey                   string
+	fetchInterval                time.Duration
+	impressionHandler            model.ImpressionHandler
+	configurationFetchedHandler  model.ConfigurationFetchedHandler
+	roxyURL                      string
+	selfManagedOptions           model.SelfManagedOptions
+	dynamicPropertyRuleHandler   model.DynamicPropertyRuleHandler
+	networkConfigurationsOptions model.NetworkConfigurationsOptions
 }
 
 func NewRoxOptions(builder RoxOptionsBuilder) model.RoxOptions {
@@ -69,15 +69,15 @@ func NewRoxOptions(builder RoxOptionsBuilder) model.RoxOptions {
 	}
 
 	return &roxOptions{
-		version:                     	version,
-		devModeKey:                  	devModeKey,
-		fetchInterval:               	fetchInterval,
-		impressionHandler:           	builder.ImpressionHandler,
-		configurationFetchedHandler: 	builder.ConfigurationFetchedHandler,
-		roxyURL:                     	builder.RoxyURL,
-		selfManagedOptions:          	builder.SelfManagedOptions,
-		dynamicPropertyRuleHandler:  	dynamicPropertyRuleHandler,
-		networkConfigurationsOptions:	builder.NetworkConfigurationsOptions,
+		version:                      version,
+		devModeKey:                   devModeKey,
+		fetchInterval:                fetchInterval,
+		impressionHandler:            builder.ImpressionHandler,
+		configurationFetchedHandler:  builder.ConfigurationFetchedHandler,
+		roxyURL:                      builder.RoxyURL,
+		selfManagedOptions:           builder.SelfManagedOptions,
+		dynamicPropertyRuleHandler:   dynamicPropertyRuleHandler,
+		networkConfigurationsOptions: builder.NetworkConfigurationsOptions,
 	}
 }
 


### PR DESCRIPTION
changing e2e to work with container (custom urls)

adding custom saas env to put whatever network url (removing trailing `/` - other SDKs might need it, not sure where we want to remove it, maybe in the driver, and the SDK should accept trailing `/` 🤷 )
creating network configs interface
creating network configs struct
creating network configs builder to easily create the struct (like roxOptions and roxSelfManagedOptions have)
adding the network configs to roxOptions