### PR TITLE
SFM-3413: Config fetcher thread stops after 1 iteration

### DIFF
--- a/v5/core/client/device_properties.go
+++ b/v5/core/client/device_properties.go
@@ -41,7 +41,7 @@ func (*deviceProperties) RolloutEnvironment() string {
 }
 
 func (*deviceProperties) LibVersion() string {
-	return "5.0.4"
+	return "5.0.5"
 }
 
 func (dp *deviceProperties) RolloutKey() string {

--- a/v5/core/core.go
+++ b/v5/core/core.go
@@ -142,7 +142,7 @@ func (core *Core) Setup(sdkSettings model.SdkSettings, deviceProperties model.De
 		}
 
 		if roxOptions != nil && roxOptions.FetchInterval() != 0 {
-			go utils.RunPeriodicTask(func() {
+			utils.RunPeriodicTask(func() {
 				<-core.Fetch()
 			}, roxOptions.FetchInterval(), core.quit)
 		}

--- a/v5/core/utils/periodic_task.go
+++ b/v5/core/utils/periodic_task.go
@@ -1,15 +1,24 @@
 package utils
 
-import "time"
+import (
+	"time"
+)
 
 func RunPeriodicTask(action func(), period time.Duration, quit <-chan struct{}) {
-	ticker := time.NewTicker(period)
-	defer ticker.Stop()
+	go func() {
+		// Start a new ticker to execute the task
+		ticker := time.NewTicker(period)
 
-	select {
-	case <-ticker.C:
-		action()
-	case <-quit:
-		return
-	}
+		// Loop forever, executing the task on each tick. Only stop when the "quit"
+		// channel tells us to, or the channel is closed.
+		for {
+			select {
+			case <-ticker.C:
+				action()
+			case <-quit:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
 }


### PR DESCRIPTION
The background thread that periodically fetches the config stops after 1 iteration.

This is because the `RunPeriodicTask` function creates a new `Ticker`, but only waits for the 1st tick.  After the first tick, the `RunPeriodicTask` function completes, and I guess the `Ticker` is left running, but as a dangling, unclosed resource.

This fix wraps the `select` statement that checks for the ticks in a `for` loop that keeps going, responding to the ticks, or until the `quit` channel is closed.

Tested this out on a local project to verify (a) the original problem, (b) that the fetcher thread was working continuously as expected after the fix and (c) that the `Ticker` would be closed on `rox.Shutdown()`.