### PR TITLE
the debouncer test fails on GHA.

### DIFF
--- a/v5/core/utils/debouncer_test.go
+++ b/v5/core/utils/debouncer_test.go
@@ -38,10 +38,10 @@ func TestWillTestDebouncerSkipDoubleInvoke(t *testing.T) {
 	assert.Equal(t, 0, counter)
 	debouncer.Invoke()
 	assert.Equal(t, 0, counter)
-	timer = time.NewTimer(600 * time.Millisecond)
+	timer = time.NewTimer(700 * time.Millisecond)
 	<-timer.C
 	assert.Equal(t, 1, counter)
-	timer = time.NewTimer(600 * time.Millisecond)
+	timer = time.NewTimer(500 * time.Millisecond)
 	<-timer.C
 	assert.Equal(t, 1, counter)
 }
@@ -55,12 +55,12 @@ func TestWillTestDebouncerInvokeAfterInvoke(t *testing.T) {
 	assert.Equal(t, 0, counter)
 	debouncer.Invoke()
 	assert.Equal(t, 0, counter)
-	timer := time.NewTimer(1100 * time.Millisecond)
+	timer := time.NewTimer(1200 * time.Millisecond)
 	<-timer.C
 	assert.Equal(t, 1, counter)
 	debouncer.Invoke()
 	assert.Equal(t, 1, counter)
-	timer = time.NewTimer(800 * time.Millisecond)
+	timer = time.NewTimer(700 * time.Millisecond)
 	<-timer.C
 	assert.Equal(t, 1, counter)
 	timer = time.NewTimer(300 * time.Millisecond)


### PR DESCRIPTION
The docs for the timer we use is:
// the current time on its channel after at least duration d.

ie, "there is no guarantee it will fire on time".
This seems to be the case because tests pass when running locally, but fail on GHA, where presumably there is less CPU.

Just 'sleep' a little bit more to allow the timer to hopefully fire. 🤦 