### PR TITLE
SDP-4723 disableSignatureVerification

### DIFF
--- a/v5/core/mocks/rox_options.go
+++ b/v5/core/mocks/rox_options.go
@@ -71,3 +71,7 @@ func (m *RoxOptions) DynamicPropertyRuleHandler() model.DynamicPropertyRuleHandl
 func (m *RoxOptions) NetworkConfigurationsOptions() model.NetworkConfigurationsOptions {
 	return nil
 }
+
+func (m *RoxOptions) IsSignatureVerificationDisabled() bool {
+	return false
+}

--- a/v5/core/model/client.go
+++ b/v5/core/model/client.go
@@ -45,6 +45,7 @@ type RoxOptions interface {
 	SelfManagedOptions() SelfManagedOptions
 	DynamicPropertyRuleHandler() DynamicPropertyRuleHandler
 	NetworkConfigurationsOptions() NetworkConfigurationsOptions
+	IsSignatureVerificationDisabled() bool
 }
 
 type SdkSettings interface {

--- a/v5/core/security/signature_verifier.go
+++ b/v5/core/security/signature_verifier.go
@@ -48,3 +48,13 @@ func (sv *signatureVerifier) Verify(data, signatureBase64 string) bool {
 	err = cert.CheckSignature(x509.SHA256WithRSA, []byte(data), signature)
 	return err == nil
 }
+
+type disabledSignatureVerifier struct{}
+
+func NewDisabledSignatureVerifier() SignatureVerifier {
+	return &disabledSignatureVerifier{}
+}
+
+func (dsv *disabledSignatureVerifier) Verify(data, signatureBase64 string) bool {
+	return true
+}

--- a/v5/server/rox_options.go
+++ b/v5/server/rox_options.go
@@ -18,6 +18,7 @@ type RoxOptionsBuilder struct {
 	SelfManagedOptions           model.SelfManagedOptions
 	DynamicPropertyRuleHandler   model.DynamicPropertyRuleHandler
 	NetworkConfigurationsOptions model.NetworkConfigurationsOptions
+	DisableSignatureVerification bool
 }
 
 type roxOptions struct {
@@ -30,6 +31,7 @@ type roxOptions struct {
 	selfManagedOptions           model.SelfManagedOptions
 	dynamicPropertyRuleHandler   model.DynamicPropertyRuleHandler
 	networkConfigurationsOptions model.NetworkConfigurationsOptions
+	disableSignatureVerification bool
 }
 
 func NewRoxOptions(builder RoxOptionsBuilder) model.RoxOptions {
@@ -78,6 +80,7 @@ func NewRoxOptions(builder RoxOptionsBuilder) model.RoxOptions {
 		selfManagedOptions:           builder.SelfManagedOptions,
 		dynamicPropertyRuleHandler:   dynamicPropertyRuleHandler,
 		networkConfigurationsOptions: builder.NetworkConfigurationsOptions,
+		disableSignatureVerification: builder.DisableSignatureVerification,
 	}
 }
 
@@ -115,4 +118,8 @@ func (ro *roxOptions) DynamicPropertyRuleHandler() model.DynamicPropertyRuleHand
 
 func (ro *roxOptions) NetworkConfigurationsOptions() model.NetworkConfigurationsOptions {
 	return ro.networkConfigurationsOptions
+}
+
+func (ro *roxOptions) IsSignatureVerificationDisabled() bool {
+	return ro.disableSignatureVerification
 }


### PR DESCRIPTION
Allow signature verification to be disabled.

Note, this is an internal/undocumented feature to support the new CloudBees platform.