### PR TITLE
SDP-12703 Add Platform Impression Path

### DIFF
--- a/v5/core/client/internal_flags_test.go
+++ b/v5/core/client/internal_flags_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rollout/rox-go/v5/core/mocks"
 	"github.com/rollout/rox-go/v5/core/model"
 	"github.com/rollout/rox-go/v5/core/roxx"
+	"github.com/rollout/rox-go/v5/core/consts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -15,7 +16,7 @@ func TestInternalFlagsWillReturnFalseWhenNoExperiment(t *testing.T) {
 	parser := &mocks.Parser{}
 	expRepo := &mocks.ExperimentRepository{}
 	expRepo.On("GetExperimentByFlag", mock.Anything).Return(nil)
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 	internalFlags := client.NewInternalFlags(expRepo, parser, environment)
 
 	assert.False(t, internalFlags.IsEnabled("stam"))
@@ -26,7 +27,7 @@ func TestInternalFlagsWillReturnFalseWhenExpressionIsNull(t *testing.T) {
 	parser.On("EvaluateExpression", mock.Anything, mock.Anything).Return(roxx.NewEvaluationResult(nil))
 	expRepo := &mocks.ExperimentRepository{}
 	expRepo.On("GetExperimentByFlag", mock.Anything).Return(model.NewExperimentModel("id", "name", "stam", false, nil, nil))
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 	internalFlags := client.NewInternalFlags(expRepo, parser, environment)
 
 	assert.False(t, internalFlags.IsEnabled("stam"))
@@ -37,7 +38,7 @@ func TestInternalFlagsWillReturnFalseWhenExpressionIsFalse(t *testing.T) {
 	parser.On("EvaluateExpression", mock.Anything, mock.Anything).Return(roxx.NewEvaluationResult(roxx.FlagFalseValue))
 	expRepo := &mocks.ExperimentRepository{}
 	expRepo.On("GetExperimentByFlag", mock.Anything).Return(model.NewExperimentModel("id", "name", "stam", false, nil, nil))
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 	internalFlags := client.NewInternalFlags(expRepo, parser, environment)
 
 	assert.False(t, internalFlags.IsEnabled("stam"))
@@ -48,7 +49,7 @@ func TestInternalFlagsWillReturnTrueWhenExpressionIsTrue(t *testing.T) {
 	parser.On("EvaluateExpression", mock.Anything, mock.Anything).Return(roxx.NewEvaluationResult(roxx.FlagTrueValue))
 	expRepo := &mocks.ExperimentRepository{}
 	expRepo.On("GetExperimentByFlag", mock.Anything).Return(model.NewExperimentModel("id", "name", "stam", false, nil, nil))
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 	internalFlags := client.NewInternalFlags(expRepo, parser, environment)
 
 	assert.True(t, internalFlags.IsEnabled("stam"))

--- a/v5/core/client/saas_environment.go
+++ b/v5/core/client/saas_environment.go
@@ -4,10 +4,14 @@ import (
 	"github.com/rollout/rox-go/v5/core/consts"
 )
 
-type SaasEnvironment struct{}
+type SaasEnvironment struct {
+	EnvironmentAPI consts.EnvironmentAPI
+}
 
-func NewSaasEnvironment() SaasEnvironment {
-	return SaasEnvironment{}
+func NewSaasEnvironment(envAPI consts.EnvironmentAPI) SaasEnvironment {
+	return SaasEnvironment{
+		EnvironmentAPI: envAPI,
+	}
 }
 
 func (e SaasEnvironment) EnvironmentRoxyInternalPath() string {
@@ -31,7 +35,7 @@ func (e SaasEnvironment) EnvironmentStateAPIPath() string {
 }
 
 func (e SaasEnvironment) EnvironmentAnalyticsPath() string {
-	return consts.EnvironmentAnalyticsPath()
+	return consts.EnvironmentAnalyticsPath(e.EnvironmentAPI)
 }
 
 func (e SaasEnvironment) EnvironmentNotificationsPath() string {

--- a/v5/core/client/saas_environment_test.go
+++ b/v5/core/client/saas_environment_test.go
@@ -1,0 +1,66 @@
+package client
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rollout/rox-go/v5/core/consts"
+)
+
+func TestSaasEnvironmentEnvironment_PlatformAPI_Path(t *testing.T) {
+	testsCases := []struct {
+		testName string
+		osEnv    string
+		platform consts.EnvironmentAPI
+		expected string
+	}{
+		{
+			testName: "Platform QA API",
+			osEnv:    "QA",
+			platform: consts.PLATFORM_API,
+			expected: "https://api-staging.saas-dev.beescloud.com/events/flag-impressions",
+		},
+		{
+			testName: "Platform Local API",
+			osEnv:    "LOCAL",
+			platform: consts.PLATFORM_API,
+			expected: "http://127.0.0.1:8097/events/flag-impressions",
+		},
+		{
+			testName: "Platform Production API",
+			osEnv:    "",
+			platform: consts.PLATFORM_API,
+			expected: "https://api.cloudbees.io/events/flag-impressions",
+		},
+		{
+			testName: "Rollout QA API",
+			osEnv:    "QA",
+			platform: consts.ROLLOUT_API,
+			expected: "https://qaanalytic.rollout.io",
+		},
+		{
+			testName: "Rollout Local API",
+			osEnv:    "LOCAL",
+			platform: consts.ROLLOUT_API,
+			expected: "http://127.0.0.1:8787",
+		},
+		{
+			testName: "Rollout Production API",
+			osEnv:    "",
+			platform: consts.ROLLOUT_API,
+			expected: "https://analytic.rollout.io",
+		},
+	}
+
+	for _, tc := range testsCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			os.Setenv("ROLLOUT_MODE", tc.osEnv)
+			saasEnvironment := NewSaasEnvironment(tc.platform)
+			assert.Equal(t, tc.expected, saasEnvironment.EnvironmentAnalyticsPath())
+		})
+
+		os.Setenv("ROLLOUT_MODE", "")
+	}
+}

--- a/v5/core/consts/environment.go
+++ b/v5/core/consts/environment.go
@@ -2,6 +2,13 @@ package consts
 
 import "os"
 
+type EnvironmentAPI int
+
+const (
+	PLATFORM_API EnvironmentAPI = iota // SDK will utilitze Platform API endpoints
+	ROLLOUT_API                        // SDK will utilitze Rollout API endpoints
+)
+
 func EnvironmentRoxyInternalPath() string {
 	return "device/request_configuration"
 }
@@ -54,8 +61,20 @@ func EnvironmentStateAPIPath() string {
 	return "https://x-api.rollout.io/device/update_state_store"
 }
 
-func EnvironmentAnalyticsPath() string {
+// EnvironmentAnalyticsPath returns the URL for the analytics endpoint.
+// envApi: PLATFORM_API or ROLLOUT_API (default) identifies if the SDK should use the Platform API or Rollout API endpoints.
+func EnvironmentAnalyticsPath(envApi EnvironmentAPI) string {
 	rolloutMode := os.Getenv("ROLLOUT_MODE")
+
+	if envApi == PLATFORM_API {
+		switch rolloutMode {
+		case "QA":
+			return "https://api-staging.saas-dev.beescloud.com/events/flag-impressions"
+		case "LOCAL":
+			return "http://127.0.0.1:8097/events/flag-impressions"
+		}
+		return "https://api.cloudbees.io/events/flag-impressions"
+	}
 
 	switch rolloutMode {
 	case "QA":

--- a/v5/core/core.go
+++ b/v5/core/core.go
@@ -6,6 +6,7 @@ import (
 
 	uuid "github.com/google/uuid"
 
+	"github.com/rollout/rox-go/v5/core/consts"
 	"github.com/rollout/rox-go/v5/core/security"
 
 	"github.com/rollout/rox-go/v5/core/client"
@@ -76,6 +77,7 @@ func (core *Core) Setup(sdkSettings model.SdkSettings, deviceProperties model.De
 		roxyPath = roxOptions.RoxyURL()
 	}
 
+	envApi := consts.ROLLOUT_API
 	if roxyPath == "" {
 		validMongoIdPattern := "^[a-f\\d]{24}$"
 		// Try to parse it as a mongo ID (rollout.io)
@@ -86,6 +88,7 @@ func (core *Core) Setup(sdkSettings model.SdkSettings, deviceProperties model.De
 			if err != nil {
 				panic(invalidAPIKeyErrorMessage)
 			}
+			envApi = consts.PLATFORM_API
 		}
 	}
 
@@ -94,7 +97,7 @@ func (core *Core) Setup(sdkSettings model.SdkSettings, deviceProperties model.De
 	} else if roxOptions != nil && roxOptions.NetworkConfigurationsOptions() != nil {
 		core.environment = client.NewCustomEnvironment(roxOptions.NetworkConfigurationsOptions())
 	} else {
-		core.environment = client.NewSaasEnvironment()
+		core.environment = client.NewSaasEnvironment(envApi)
 	}
 
 	// TODO Analytics.Analytics.Initialize(deviceProperties.RolloutKey, deviceProperties)

--- a/v5/core/network/configuration_fetcher_test.go
+++ b/v5/core/network/configuration_fetcher_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rollout/rox-go/v5/core/client"
 	"github.com/rollout/rox-go/v5/core/configuration"
+	"github.com/rollout/rox-go/v5/core/consts"
 	"github.com/rollout/rox-go/v5/core/mocks"
 	"github.com/rollout/rox-go/v5/core/model"
 	"github.com/rollout/rox-go/v5/core/network"
@@ -25,7 +26,7 @@ func TestConfigurationFetcherWillReturnCDNDataWhenSuccessful(t *testing.T) {
 	response := &model.Response{StatusCode: http.StatusOK, Content: []byte("{\"data\": \"harti\"}")}
 	request.On("SendGet", requestData).Return(response, nil)
 
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 	requestBuilder := &mocks.RequestConfigurationBuilder{}
 	requestBuilder.On("BuildForCDN").Return(requestData)
 
@@ -51,7 +52,7 @@ func TestConfigurationFetcherWillReturnNullWhenCDNFailsWithException(t *testing.
 	request.On("SendGet", requestDataCDN).Return(nil, errors.New("not found"))
 	request.On("SendGet", requestDataAPI).Return(response, nil)
 
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 	requestBuilder := &mocks.RequestConfigurationBuilder{}
 	requestBuilder.On("BuildForCDN").Return(requestDataCDN)
 	requestBuilder.On("BuildForAPI").Return(requestDataAPI)
@@ -77,7 +78,7 @@ func TestConfigurationFetcherWillReturnNullWhenCDNFails404APIWithException(t *te
 	request.On("SendGet", requestDataCDN).Return(response, nil)
 	request.On("SendGet", requestDataAPI).Return(nil, errors.New("exception"))
 
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 	requestBuilder := &mocks.RequestConfigurationBuilder{}
 	requestBuilder.On("BuildForCDN").Return(requestDataCDN)
 	requestBuilder.On("BuildForAPI").Return(requestDataAPI)
@@ -104,7 +105,7 @@ func TestConfigurationFetcherWillReturnAPIDataWhenCDNFails404APIOK(t *testing.T)
 	request.On("SendGet", requestDataCDN).Return(responseCDN, nil)
 	request.On("SendPost", requestDataAPI.URL, requestDataAPI.QueryParams).Return(response, nil)
 
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 	requestBuilder := &mocks.RequestConfigurationBuilder{}
 	requestBuilder.On("BuildForCDN").Return(requestDataCDN)
 	requestBuilder.On("BuildForAPI").Return(requestDataAPI)
@@ -132,7 +133,7 @@ func TestConfigurationFetcherWillReturnNullDataWhenBothNotFound(t *testing.T) {
 	request.On("SendGet", requestDataCDN).Return(responseCDN, nil)
 	request.On("SendGet", requestDataAPI).Return(response, nil)
 
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 	requestBuilder := &mocks.RequestConfigurationBuilder{}
 	requestBuilder.On("BuildForCDN").Return(requestDataCDN)
 	requestBuilder.On("BuildForAPI").Return(requestDataAPI)

--- a/v5/core/network/request_configuration_builder_test.go
+++ b/v5/core/network/request_configuration_builder_test.go
@@ -29,7 +29,7 @@ func TestRequestConfigurationBuilderCDNRequestDataWillHaveDistinctID(t *testing.
 	appKey := "ABCD"
 	deviceProps.On("RolloutKey").Return(appKey)
 
-	requestConfigurationBuilder := network.NewRequestConfigurationBuilder(sdkSettings, buid, deviceProps, "", client.NewSaasEnvironment())
+	requestConfigurationBuilder := network.NewRequestConfigurationBuilder(sdkSettings, buid, deviceProps, "", client.NewSaasEnvironment(consts.ROLLOUT_API))
 	result := requestConfigurationBuilder.BuildForCDN()
 
 	assert.Equal(t, fmt.Sprintf("%s/%s/123", consts.EnvironmentCDNPath(), appKey), result.URL)
@@ -56,7 +56,7 @@ func TestRequestConfigurationBuilderRoxyRequestDataWillHaveServerData(t *testing
 	appKey := "ABCD"
 	deviceProps.On("RolloutKey").Return(appKey)
 
-	requestConfigurationBuilder := network.NewRequestConfigurationBuilder(sdkSettings, buid, deviceProps, "http://bimba.bobi.o.ponpon", client.NewSaasEnvironment())
+	requestConfigurationBuilder := network.NewRequestConfigurationBuilder(sdkSettings, buid, deviceProps, "http://bimba.bobi.o.ponpon", client.NewSaasEnvironment(consts.ROLLOUT_API))
 	result := requestConfigurationBuilder.BuildForRoxy()
 
 	assert.Equal(t, "http://bimba.bobi.o.ponpon/device/request_configuration", result.URL)
@@ -88,7 +88,7 @@ func TestRequestConfigurationBuilderAPIRequestDataWillHaveServerData(t *testing.
 	appKey := "ABCD"
 	deviceProps.On("RolloutKey").Return(appKey)
 
-	requestConfigurationBuilder := network.NewRequestConfigurationBuilder(sdkSettings, buid, deviceProps, "", client.NewSaasEnvironment())
+	requestConfigurationBuilder := network.NewRequestConfigurationBuilder(sdkSettings, buid, deviceProps, "", client.NewSaasEnvironment(consts.ROLLOUT_API))
 	result := requestConfigurationBuilder.BuildForAPI()
 
 	assert.Equal(t, fmt.Sprintf("%s/%s/123", consts.EnvironmentAPIPath(), appKey), result.URL)

--- a/v5/core/network/state_sender_test.go
+++ b/v5/core/network/state_sender_test.go
@@ -41,7 +41,7 @@ func TestWillSerializeFlags(t *testing.T) {
 	flagRepo.On("GetAllFlags").Return([]model.Variant{flag})
 	flagRepo.On("RegisterFlagAddedHandler", mock.Anything).Return()
 	cpRepo := repositories.NewCustomPropertyRepository()
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 
 	stateSender := NewStateSender(request, dp, flagRepo, cpRepo, environment, false)
 
@@ -85,7 +85,7 @@ func TestWillSerializeFlagsNewPlatformFormat(t *testing.T) {
 	flagRepo.On("GetAllFlags").Return([]model.Variant{flagStr, flagBln, flagInt, flagFlt})
 	flagRepo.On("RegisterFlagAddedHandler", mock.Anything).Return()
 	cpRepo := repositories.NewCustomPropertyRepository()
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 
 	stateSender := NewStateSender(request, dp, flagRepo, cpRepo, environment, true)
 
@@ -167,7 +167,7 @@ func TestWillSerializeProps(t *testing.T) {
 	cpRepo := &mocks.CustomPropertyRepository{}
 	cpRepo.On("GetAllCustomProperties").Return([]*properties.CustomProperty{cp})
 	cpRepo.On("RegisterPropertyAddedHandler", mock.Anything).Return()
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 
 	stateSender := NewStateSender(request, dp, flagRepo, cpRepo, environment, false)
 
@@ -202,7 +202,7 @@ func TestWillSerializePropsInNewPlatformFormat(t *testing.T) {
 	cpRepo := &mocks.CustomPropertyRepository{}
 	cpRepo.On("GetAllCustomProperties").Return([]*properties.CustomProperty{cpStr, cpBln, cpFlt, cpInt, cpSmv, cpDt})
 	cpRepo.On("RegisterPropertyAddedHandler", mock.Anything).Return()
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 
 	stateSender := NewStateSender(request, dp, flagRepo, cpRepo, environment, true)
 
@@ -251,7 +251,7 @@ func TestWillCallOnlyCDNStateMD5ChangesForFlag(t *testing.T) {
 	cpRepo := repositories.NewCustomPropertyRepository()
 	dp := &mocks.DeviceProperties{}
 	dp.On("GetAllProperties").Return(createNewDeviceProp())
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 
 	var requestData model.RequestData
 	response := &model.Response{StatusCode: http.StatusOK, Content: []byte("{\"result\": 200}")}
@@ -277,7 +277,7 @@ func TestWillCallOnlyCDNStateMD5ChangesForCustomProperty(t *testing.T) {
 	cpRepo := repositories.NewCustomPropertyRepository()
 	dp := &mocks.DeviceProperties{}
 	dp.On("GetAllProperties").Return(createNewDeviceProp())
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 
 	var requestData model.RequestData
 	response := &model.Response{StatusCode: http.StatusOK, Content: []byte("{\"result\": 200}")}
@@ -303,7 +303,7 @@ func TestWillCallOnlyCDNStateMD5FlagOrderNotImportant(t *testing.T) {
 	cpRepo := repositories.NewCustomPropertyRepository()
 	dp := &mocks.DeviceProperties{}
 	dp.On("GetAllProperties").Return(createNewDeviceProp())
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 
 	var requestData model.RequestData
 	response := &model.Response{StatusCode: http.StatusOK, Content: []byte("{\"result\": 200}")}
@@ -333,7 +333,7 @@ func TestWillCallOnlyCDNStateMD5CustomPropertyOrderNotImportant(t *testing.T) {
 	cpRepo := repositories.NewCustomPropertyRepository()
 	dp := &mocks.DeviceProperties{}
 	dp.On("GetAllProperties").Return(createNewDeviceProp())
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 
 	var requestData model.RequestData
 	response := &model.Response{StatusCode: http.StatusOK, Content: []byte("{\"result\": 200}")}
@@ -362,7 +362,7 @@ func TestWillReturnNullWhenCDNFailsWithException(t *testing.T) {
 	cpRepo := repositories.NewCustomPropertyRepository()
 	dp := &mocks.DeviceProperties{}
 	dp.On("GetAllProperties").Return(createNewDeviceProp())
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 
 	var reqCDNData model.RequestData
 	var reqAPIData model.RequestData
@@ -390,7 +390,7 @@ func TestWillReturnNullWhenCDNSucceedWithEmptyResponse(t *testing.T) {
 	cpRepo := repositories.NewCustomPropertyRepository()
 	dp := &mocks.DeviceProperties{}
 	dp.On("GetAllProperties").Return(createNewDeviceProp())
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 
 	var reqCDNData model.RequestData
 	var reqAPIData string
@@ -418,7 +418,7 @@ func TestWillReturnNullWhenCDNSucceedWithNotJsonResponse(t *testing.T) {
 	cpRepo := repositories.NewCustomPropertyRepository()
 	dp := &mocks.DeviceProperties{}
 	dp.On("GetAllProperties").Return(createNewDeviceProp())
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 
 	var reqCDNData model.RequestData
 	var reqAPIData string
@@ -446,7 +446,7 @@ func TestWillReturnNullWhenCDNFails404APIWithException(t *testing.T) {
 	cpRepo := repositories.NewCustomPropertyRepository()
 	dp := &mocks.DeviceProperties{}
 	dp.On("GetAllProperties").Return(createNewDeviceProp())
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 
 	var reqCDNData model.RequestData
 	var reqAPIData string
@@ -475,7 +475,7 @@ func TestWillReturnAPIDataWhenCDNSucceedWithResult404APIOK(t *testing.T) {
 	cpRepo := repositories.NewCustomPropertyRepository()
 	dp := &mocks.DeviceProperties{}
 	dp.On("GetAllProperties").Return(createNewDeviceProp())
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 
 	var reqCDNData model.RequestData
 	var reqAPIData string

--- a/v5/core/security/signature_verifier_test.go
+++ b/v5/core/security/signature_verifier_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 
 	"github.com/rollout/rox-go/v5/core/client"
+	"github.com/rollout/rox-go/v5/core/consts"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSignatureVerifierShouldVerifyWithROXSignature(t *testing.T) {
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 	var sigVerify = NewSignatureVerifier(environment)
 	data := `{"__v":0,"application":"5465dd938ede8bfa5c4a40b9","pending_test_devices":false,"_id":"5465e0848ede8bfa5c4a40c8","tweak":{"sandbox_bundle_url":"http://api.rollout.io/device/5465dd938ede8bfa5c4a40b9/5465deb829f2ed0b638982cb/tweaks_bundles/sandbox","bundle":{"app_version":"5465deb829f2ed0b638982cb","bucket":"production","_id":"5465e0848ede8bfa5c4a40c7","__v":0,"creation_date":"2014-11-14T10:59:16.728Z"},"bundles":[]},"structure":{"md5":{"armv7":"5cda09a29184ae745c9ce24cea5f49c8","i386":"e800a916b1c119418b737ea3b7ffcb44"},"force_upload":0,"upload_url":"http://api.rollout.io/device/5465dd938ede8bfa5c4a40b9/5465deb829f2ed0b638982cb/structures"},"devices":{"mode":{"4E922AEE-0616-4135-98A0-1DDF04910087":"sandbox"}},"application_version":{"id":"5465deb829f2ed0b638982cb","release_version_number":"1.0","rollout_api_version":"1.1.0"},"api_version":"1.0.0","creation_date":"2014-11-14T10:59:16.743Z"}`
 	signature := "BsJiQvPn0/fH7EABe/mWEwLeldqxQiccQH0SRmjk4p9u76Z+wbmYXym6YqLbwCPYiciHYl7F7HRE0duOMlx4Rz2HMos8mp6DIwVw4cKfzrcBa+abL56PJa6Be9VB99nwjgagesyvSuTl4nd9u/secgHSTP1dh7xJxcFheK1ouXDcHrznvGDTG/LL+fk0FoqovQV2NWjCQFWAqyXkHp5xZ5YveMPjyaHYtHLfPevSidsKK3Pn5Oi7COrw4GWDI8WcvEt/L4hOtsb0nn/hka0VlVmfa6pUPk0aAL5cxQ0kC82YJ7X0xhZ4RqRcUoxaMMr8gM40I5zHyXE7wLe9NWDMwA=="
@@ -17,7 +18,7 @@ func TestSignatureVerifierShouldVerifyWithROXSignature(t *testing.T) {
 }
 
 func TestSignatureVerifierShouldNotVerifyWithROXSignature(t *testing.T) {
-	environment := client.NewSaasEnvironment()
+	environment := client.NewSaasEnvironment(consts.ROLLOUT_API)
 	var sigVerify = NewSignatureVerifier(environment)
 	data := `{"__v":0,"application":"5465dd938ede8bfa5c4a40b9","pending_test_devices":false,"_id":"5465e0848ede8bfa5c4a40c8","tweak":{"sandbox_bundle_url":"http://api.rollout.io/device/5465dd938ede8bfa5c4a40b9/5465deb829f2ed0b638982cb/tweaks_bundles/sandbox","bundle":{"app_version":"5465deb829f2ed0b638982cb","bucket":"production","_id":"5465e0848ede8bfa5c4a40c7","__v":0,"creation_date":"2014-11-14T10:59:16.728Z"},"bundles":[]},"structure":{"md5":{"armv7":"5cda09a29184ae745c9ce24cea5f49c8","i386":"e800a916b1c119418b737ea3b7ffcb44"},"force_upload":0,"upload_url":"http://api.rollout.io/device/5465dd938ede8bfa5c4a40b9/5465deb829f2ed0b638982cb/structures"},"devices":{"mode":{"4E922AEE-0616-4135-98A0-1DDF04910087":"sandbox"}},"application_version":{"id":"5465deb829f2ed0b638982cb","release_version_number":"1.0","rollout_api_version":"1.1.0"},"api_version":"1.0.0","creation_date":"2014-11-14T10:59:16.743Z"}`
 	signature := "AsJiQvPn0/fH7EABe/mWEwLeldqxQiccQH0SRmjk4p9u76Z+wbmYXym6YqLbwCPYiciHYl7F7HRE0duOMlx4Rz2HMos8mp6DIwVw4cKfzrcBa+abL56PJa6Be9VB99nwjgagesyvSuTl4nd9u/secgHSTP1dh7xJxcFheK1ouXDcHrznvGDTG/LL+fk0FoqovQV2NWjCQFWAqyXkHp5xZ5YveMPjyaHYtHLfPevSidsKK3Pn5Oi7COrw4GWDI8WcvEt/L4hOtsb0nn/hka0VlVmfa6pUPk0aAL5cxQ0kC82YJ7X0xhZ4RqRcUoxaMMr8gM40I5zHyXE7wLe9NWDMwA=="


### PR DESCRIPTION
[JIRA Ticket SD-12703](https://cloudbees.atlassian.net/browse/SDP-12703)

Adds impressions path for Platform API contingent upon UUID in use or not.

⚠️  While impressions handler is implemented for Go SDK, the analytics logic doesn't exist (v4 or v5). The impressions analytics (impressions) path isn't utilized anywhere and Go SDK doesn't won't collect impressions.
Need a separate ticket to implement this, if we even want to 'turn on analytics for Go SDK'.