### PR TITLE
fixing update state url for rollout

### DIFF
--- a/v5/core/client/saas_environment_test.go
+++ b/v5/core/client/saas_environment_test.go
@@ -98,7 +98,7 @@ func TestSaasEnvironmentEnvironment_PlatformAPI_Path(t *testing.T) {
 				CDN:           "https://conf.rollout.io",
 				API:           "https://x-api.rollout.io/device/get_configuration",
 				StateCDN:      "https://statestore.rollout.io",
-				StateAPI:      "https://api.cloudbees.io/device/update_state_store",
+				StateAPI:      "https://x-api.rollout.io/device/update_state_store",
 				Analytics:     "https://analytic.rollout.io",
 				Notifications: "https://push.rollout.io/sse",
 			},

--- a/v5/core/consts/environment.go
+++ b/v5/core/consts/environment.go
@@ -75,7 +75,7 @@ func EnvironmentStateAPIPath(envApi EnvironmentAPI) string {
 	if envApi == PLATFORM_API {
 		return "https://api.cloudbees.io/device/update_state_store"
 	}
-	return "https://api.cloudbees.io/device/update_state_store"
+	return "https://x-api.rollout.io/device/update_state_store"
 }
 
 // EnvironmentAnalyticsPath returns the URL for the analytics endpoint.


### PR DESCRIPTION
think the latest version we released included it 😞 

we might think about deleting it (5.0.9)