### PR TITLE
Updating release to 5.0.10.

### DIFF
--- a/v5/core/client/device_properties.go
+++ b/v5/core/client/device_properties.go
@@ -41,7 +41,7 @@ func (*deviceProperties) RolloutEnvironment() string {
 }
 
 func (*deviceProperties) LibVersion() string {
-	return "5.0.9"
+	return "5.0.10"
 }
 
 func (dp *deviceProperties) RolloutKey() string {


### PR DESCRIPTION
Creating new 5.0.10 release to use in CBP services when migrating them to CBP.